### PR TITLE
Lookup Table Merging

### DIFF
--- a/tact/API/tact_api.py
+++ b/tact/API/tact_api.py
@@ -96,6 +96,30 @@ def upload_file():
         return make_response(({"message": "File(s) uploaded but config update failed"}, 500))
 
 
+@app.route("/upload_lookup", methods=["POST"])
+def upload_lookup_file():
+    if "file" not in request.files:
+        return make_response(({"message": "No file part"}, 400))
+
+    file = request.files.get("file")
+
+    if not file or not file.filename:
+        return make_response(({"message": "No selected file"}, 400))
+
+    session_id = "default_user"
+    upload_lookup_dir = path.join("/tmp/uploads", session_id, "lookup")
+    makedirs(upload_lookup_dir, exist_ok=True)
+
+    basename = secure_filename(path.basename(file.filename))
+    file_path = path.join(upload_lookup_dir, basename)
+    file.save(file_path)
+
+    if controller.upload_lookup_file(file_path):
+        return make_response(({"message": "Lookup file uploaded and config updated"}, 200))
+    else:
+        return make_response(({"message": "Lookup file uploaded but config update failed"}, 500))
+
+
 @app.route("/analysis")
 def analysis():
     if controller.analyze():
@@ -168,11 +192,16 @@ def transform():
             return make_response(("Taxonomic names merged.", 200))
         else:
             return make_response(("Failed to merge taxonomic names.", 404))
+    elif operation == "merge_lookup":
+        if controller.lookup_data():
+            return make_response(("Lookup merge complete.", 200))
+        else:
+            return make_response(("Lookup merge failed.", 404))
     else:
         return make_response(
             (
                 {
-                    "message": "Invalid operation, please select enumerate_columns, combine_rows, or merge_taxa."
+                    "message": "Invalid operation, please select enumerate_columns, combine_rows, merge_taxa, or merge_lookup."
                 },
                 400,
             )

--- a/tact/API/tact_api.py
+++ b/tact/API/tact_api.py
@@ -61,7 +61,13 @@ def upload_file():
     # Create a unique directory for current session
     # For future multi-user support, replace with the actual session UUID
     session_id = "default_user"
-    upload_batch_dir = path.join("/tmp/uploads", session_id)
+
+    upload_type = request.args.get("type", "parser")
+
+    if upload_type == "lookup":
+        upload_batch_dir = path.join("/tmp/uploads/lookup", session_id)
+    else:
+        upload_batch_dir = path.join("/tmp/uploads", session_id)
     
     # Wipe the user's directory to prevent endless file accumulation
     if path.exists(upload_batch_dir):
@@ -85,39 +91,23 @@ def upload_file():
     is_directory = len(saved_files) > 1
     input_path = upload_batch_dir if is_directory else saved_files[0]
     path_for_preview = saved_files[0]
+
+    if upload_type == "lookup":
+        success = controller.update_settings("transform", {
+            "lookup_path": input_path,
+        })
+        controller.update_lookup_config()
+    else:
+        success = controller.update_settings("parser", {
+            "inputPath": input_path, 
+            "pathForPreview": path_for_preview, 
+            "isDirectory": is_directory
+        })
     
-    if controller.update_settings("parser", {
-        "inputPath": input_path, 
-        "pathForPreview": path_for_preview, 
-        "isDirectory": is_directory
-    }):
+    if success:
         return make_response(({"message": "File(s) uploaded and config updated"}, 200))
     else:
         return make_response(({"message": "File(s) uploaded but config update failed"}, 500))
-
-
-@app.route("/upload_lookup", methods=["POST"])
-def upload_lookup_file():
-    if "file" not in request.files:
-        return make_response(({"message": "No file part"}, 400))
-
-    file = request.files.get("file")
-
-    if not file or not file.filename:
-        return make_response(({"message": "No selected file"}, 400))
-
-    session_id = "default_user"
-    upload_lookup_dir = path.join("/tmp/uploads", session_id, "lookup")
-    makedirs(upload_lookup_dir, exist_ok=True)
-
-    basename = secure_filename(path.basename(file.filename))
-    file_path = path.join(upload_lookup_dir, basename)
-    file.save(file_path)
-
-    if controller.upload_lookup_file(file_path):
-        return make_response(({"message": "Lookup file uploaded and config updated"}, 200))
-    else:
-        return make_response(({"message": "Lookup file uploaded but config update failed"}, 500))
 
 
 @app.route("/analysis")
@@ -193,7 +183,7 @@ def transform():
         else:
             return make_response(("Failed to merge taxonomic names.", 404))
     elif operation == "merge_lookup":
-        if controller.lookup_data():
+        if controller.merge_lookup_data():
             return make_response(("Lookup merge complete.", 200))
         else:
             return make_response(("Lookup merge failed.", 404))

--- a/tact/UI/react/src/components/TransformPage.jsx
+++ b/tact/UI/react/src/components/TransformPage.jsx
@@ -214,6 +214,10 @@ const TransformPage = () => {
                 setTransformConfig(configData);
                 setLookupUploadResult({ success: true });
                 setMsg({ text: '', type: '' });
+                // Clear the file input so the same file can be re-uploaded
+                const fileInput = document.getElementById('lookupFileInput');
+                if (fileInput) fileInput.value = '';
+                setLookupFile([]);
             } else {
                 const err = await res.json().catch(() => ({}));
                 setLookupUploadResult({ success: false });
@@ -250,8 +254,9 @@ const TransformPage = () => {
                 setLookupMergeResult({ success: true });
                 setMsg({ text: '', type: '' });
             } else {
+                const errBody = await mergeRes.json().catch(() => ({}));
                 setLookupMergeResult({ success: false });
-                setMsg({ text: 'Lookup merge failed.', type: 'error' });
+                setMsg({ text: `Lookup merge failed: ${errBody.message || mergeRes.statusText}`, type: 'error' });
             }
         } catch (err) {
             setLookupMergeResult({ success: false });

--- a/tact/UI/react/src/components/TransformPage.jsx
+++ b/tact/UI/react/src/components/TransformPage.jsx
@@ -206,7 +206,7 @@ const TransformPage = () => {
         try {
             const formData = new FormData();
             formData.append('file', lookupFile[0]);
-            const res = await fetch('/upload_lookup', { method: 'POST', body: formData });
+            const res = await fetch('/upload?type=lookup', { method: 'POST', body: formData });
             if (res.ok) {
                 // Refresh transform config to get updated lookup_file_path & lookup_field_names
                 const configRes = await fetch('/config/transform');
@@ -652,7 +652,7 @@ const TransformPage = () => {
                 </div>
 
                 <button className="primary" onClick={handleMergeLookup} disabled={isMergingLookup}>
-                    {isMergingLookup ? 'Merging...' : 'Merge Lookup!'}
+                    {isMergingLookup ? 'Merging...' : 'Merge Lookup'}
                 </button>
 
                 {isMergingLookup && (
@@ -662,7 +662,7 @@ const TransformPage = () => {
                 )}
                 {lookupMergeResult && lookupMergeResult.success && (
                     <div className="status-message success" style={{ marginTop: '10px' }}>
-                        ✅ Success — lookup merged!
+                        ✅ Success — lookup merged.
                     </div>
                 )}
                 {lookupMergeResult && !lookupMergeResult.success && (

--- a/tact/UI/react/src/components/TransformPage.jsx
+++ b/tact/UI/react/src/components/TransformPage.jsx
@@ -82,6 +82,11 @@ const TransformPage = () => {
         fetchData();
     }, []);
 
+    // ─── Transform Config Helper (mirrors CleanPage pattern) ─────────────────
+    const handleTransformConfigChange = (key, value) => {
+        setTransformConfig(prev => ({ ...prev, [key]: value }));
+    };
+
     const handleRegexChange = (val) => {
         setRegexPattern(val);
         if (val) {
@@ -176,6 +181,83 @@ const TransformPage = () => {
             setMsg({ text: `Error: ${err.message}`, type: 'error' });
         } finally {
             setIsCombining(false);
+        }
+    };
+
+    // ─── Lookup Upload & Merge ─────────────────────────────────────────────────
+    const [lookupFile, setLookupFile] = useState([]);
+    const [isUploadingLookup, setIsUploadingLookup] = useState(false);
+    const [isMergingLookup, setIsMergingLookup] = useState(false);
+    const [lookupUploadResult, setLookupUploadResult] = useState(null);
+    const [lookupMergeResult, setLookupMergeResult] = useState(null);
+
+    const handleLookupFileChange = (e) => {
+        if (e.target.files && e.target.files.length > 0) {
+            setLookupFile(Array.from(e.target.files));
+            setLookupUploadResult(null);
+        }
+    };
+
+    const handleLookupUpload = async () => {
+        if (lookupFile.length === 0) return;
+        setIsUploadingLookup(true);
+        setLookupUploadResult(null);
+        setMsg({ text: 'Uploading lookup file...', type: 'info' });
+        try {
+            const formData = new FormData();
+            formData.append('file', lookupFile[0]);
+            const res = await fetch('/upload_lookup', { method: 'POST', body: formData });
+            if (res.ok) {
+                // Refresh transform config to get updated lookup_file_path & lookup_field_names
+                const configRes = await fetch('/config/transform');
+                const configData = await configRes.json();
+                setTransformConfig(configData);
+                setLookupUploadResult({ success: true });
+                setMsg({ text: '', type: '' });
+            } else {
+                const err = await res.json().catch(() => ({}));
+                setLookupUploadResult({ success: false });
+                setMsg({ text: `Upload failed: ${err.message || res.statusText}`, type: 'error' });
+            }
+        } catch (err) {
+            setLookupUploadResult({ success: false });
+            setMsg({ text: `Error: ${err.message}`, type: 'error' });
+        } finally {
+            setIsUploadingLookup(false);
+        }
+    };
+
+    const handleMergeLookup = async () => {
+        setIsMergingLookup(true);
+        setLookupMergeResult(null);
+        setMsg({ text: 'Saving config and merging...', type: 'info' });
+        try {
+            const outgoingConfig = {
+                lookup_key_column: transformConfig?.lookup_key_column || '',
+                target_key_column: transformConfig?.target_key_column || '',
+                lookup_value_columns: transformConfig?.lookup_value_columns || [],
+                lookup_output_path: transformConfig?.lookup_output_path || '',
+            };
+            const configRes = await fetch('/config/transform', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(outgoingConfig),
+            });
+            if (!configRes.ok) throw new Error('Config update failed');
+
+            const mergeRes = await fetch('/transform?operation=merge_lookup', { method: 'POST' });
+            if (mergeRes.ok) {
+                setLookupMergeResult({ success: true });
+                setMsg({ text: '', type: '' });
+            } else {
+                setLookupMergeResult({ success: false });
+                setMsg({ text: 'Lookup merge failed.', type: 'error' });
+            }
+        } catch (err) {
+            setLookupMergeResult({ success: false });
+            setMsg({ text: `Error: ${err.message}`, type: 'error' });
+        } finally {
+            setIsMergingLookup(false);
         }
     };
 
@@ -465,6 +547,122 @@ const TransformPage = () => {
                 {combineResult && !combineResult.success && (
                     <div className="status-message error" style={{ marginTop: '10px' }}>
                         ❌ Failed to combine rows. Check the API logs for details.
+                    </div>
+                )}
+            </div>
+
+            {/* ── Section 3: Lookup Merge ───────────────────────────────────── */}
+            <div className="section config-form-container">
+                <h3>Lookup Merge</h3>
+                <p style={{ marginBottom: '1rem' }}>
+                    Join an external lookup table to the active dataset. Rows are matched
+                    on a key column; you can copy selected columns or the entire lookup row
+                    into the target dataset.
+                </p>
+
+                {/* Step 1: Upload lookup file */}
+                <div className="form-group">
+                    <label>Step 1 — Upload Lookup Table (CSV)</label>
+                    <div style={{ display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap' }}>
+                        <input
+                            id="lookupFileInput"
+                            type="file"
+                            accept=".csv"
+                            onChange={handleLookupFileChange}
+                        />
+                        <button
+                            className="secondary"
+                            onClick={handleLookupUpload}
+                            disabled={isUploadingLookup || lookupFile.length === 0}
+                        >
+                            {isUploadingLookup ? 'Uploading...' : 'Upload'}
+                        </button>
+                    </div>
+                    {lookupUploadResult && lookupUploadResult.success && (
+                        <div className="status-message success" style={{ marginTop: '6px' }}>
+                            ✅ Lookup file uploaded — columns loaded.
+                        </div>
+                    )}
+                    {lookupUploadResult && !lookupUploadResult.success && (
+                        <div className="status-message error" style={{ marginTop: '6px' }}>
+                            ❌ Upload failed. Check logs for details.
+                        </div>
+                    )}
+                    {transformConfig?.lookup_file_path && (
+                        <div style={{ marginTop: '6px', fontSize: '0.85em', color: '#888' }}>
+                            Active lookup file: <code>{transformConfig.lookup_file_path}</code>
+                        </div>
+                    )}
+                </div>
+
+                {/* Step 2: Configure keys */}
+                <div className="responsive-grid grid-2-col">
+                    <div className="form-group">
+                        <label>Step 2a — Key Column in Lookup Table</label>
+                        <select
+                            value={transformConfig?.lookup_key_column || ''}
+                            onChange={e => handleTransformConfigChange('lookup_key_column', e.target.value)}
+                        >
+                            <option value="">-- Select --</option>
+                            {(transformConfig?.lookup_field_names || []).map(c => (
+                                <option key={c} value={c}>{c}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="form-group">
+                        <label>Step 2b — Key Column in Target Dataset</label>
+                        <select
+                            value={transformConfig?.target_key_column || ''}
+                            onChange={e => handleTransformConfigChange('target_key_column', e.target.value)}
+                        >
+                            <option value="">-- Select --</option>
+                            {dataColumns.map(c => (
+                                <option key={c} value={c}>{c}</option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+
+                {/* Step 3: Columns to copy */}
+                <div className="form-group">
+                    <label>Step 3 — Columns to Copy from Lookup Table</label>
+                    <MultiSelect
+                        options={transformConfig?.lookup_field_names || []}
+                        selected={transformConfig?.lookup_value_columns || []}
+                        onChange={selected => handleTransformConfigChange('lookup_value_columns', selected)}
+                        onSelectAll={() => handleTransformConfigChange('lookup_value_columns', [...(transformConfig?.lookup_field_names || [])])}
+                        emptyMessage="Upload a lookup file first to populate column list."
+                    />
+                </div>
+
+                {/* Output path */}
+                <div className="form-group">
+                    <label>Output Path</label>
+                    <input
+                        type="text"
+                        value={transformConfig?.lookup_output_path || ''}
+                        placeholder="path/to/merged_output.csv"
+                        onChange={e => handleTransformConfigChange('lookup_output_path', e.target.value)}
+                    />
+                </div>
+
+                <button className="primary" onClick={handleMergeLookup} disabled={isMergingLookup}>
+                    {isMergingLookup ? 'Merging...' : 'Merge Lookup!'}
+                </button>
+
+                {isMergingLookup && (
+                    <div className="status-message info" style={{ marginTop: '10px' }}>
+                        ⏳ Merging lookup table, please wait...
+                    </div>
+                )}
+                {lookupMergeResult && lookupMergeResult.success && (
+                    <div className="status-message success" style={{ marginTop: '10px' }}>
+                        ✅ Success — lookup merged!
+                    </div>
+                )}
+                {lookupMergeResult && !lookupMergeResult.success && (
+                    <div className="status-message error" style={{ marginTop: '10px' }}>
+                        ❌ Merge failed. Check the API logs for details.
                     </div>
                 )}
             </div>

--- a/tact/UI/react/src/components/TransformPage.jsx
+++ b/tact/UI/react/src/components/TransformPage.jsx
@@ -561,8 +561,7 @@ const TransformPage = () => {
                 <h3>Lookup Merge</h3>
                 <p style={{ marginBottom: '1rem' }}>
                     Join an external lookup table to the active dataset. Rows are matched
-                    on a key column; you can copy selected columns or the entire lookup row
-                    into the target dataset.
+                    on a key column.
                 </p>
 
                 {/* Step 1: Upload lookup file */}

--- a/tact/control/controller.py
+++ b/tact/control/controller.py
@@ -120,7 +120,7 @@ def get_data(kwargs: Dict = {}) -> Union[pd.DataFrame, str, Dict]:
             elif request_type == "transform":
                 file_path = config.get("transform_output_path")
             elif request_type == "lookup":
-                file_path = config.get("lookup_path")
+                file_path = config.get("lookup_file_path")
     except ValueError as e:
         logger.error(
             f"Unknown request type: {request_type}: {e}"

--- a/tact/control/controller.py
+++ b/tact/control/controller.py
@@ -583,6 +583,84 @@ def evaluate_forecast() -> Dict:
         **combined_df.to_dict()
     }
 
+
+def upload_lookup_file(file_path: str) -> bool:
+    """Reads column headers from the uploaded lookup CSV and persists the
+    file path and field names into the transform config.
+
+    Args:
+        file_path (str): Absolute path to the uploaded lookup CSV file.
+
+    Returns:
+        bool: True if config was updated successfully.
+    """
+    logger.info(f"Processing uploaded lookup file: {file_path}")
+    try:
+        # Read only the header row to extract column names
+        lookup_df = pd.read_csv(file_path, nrows=0)
+        field_names = list(lookup_df.columns)
+        logger.debug(f"Lookup file columns: {field_names}")
+
+        return update_settings("transform", {
+            "lookup_file_path": file_path,
+            "lookup_field_names": field_names,
+        })
+    except Exception as e:
+        logger.error(f"Failed to process lookup file: {e}")
+        return False
+
+
+def lookup_data() -> bool:
+    """Reads lookup/merge configuration from the transform config and
+    delegates to the processing module.
+
+    Expected transform config keys:
+        lookup_file_path (str): Path to the external lookup CSV.
+        lookup_key_column (str): Key column in the lookup table.
+        target_key_column (str): Key column in the target dataset.
+        lookup_value_columns (list[str]): Columns to copy from lookup.
+        lookup_output_path (str): Path to write merged output.
+
+    Returns:
+        bool: True if merge succeeded.
+    """
+    import tact.processing.lookup_merger as lookup_merger
+
+    transform_config = get_settings_json("transform")
+    parser_config = get_settings_json("parser")
+
+    logger.info("Running lookup merge...")
+    logger.debug(f"Lookup file: {transform_config.get('lookup_file_path')}")
+    logger.debug(f"Lookup key: {transform_config.get('lookup_key_column')}")
+    logger.debug(f"Target key: {transform_config.get('target_key_column')}")
+    logger.debug(f"Value columns: {transform_config.get('lookup_value_columns')}")
+
+    target_df = get_data(kwargs={"format": "dataframe"})
+
+    try:
+        #TODO:Can we get this using get_data?
+        lookup_df = pd.read_csv(transform_config.get("lookup_file_path"))
+    except Exception as e:
+        logger.error(f"Failed to read lookup file: {e}")
+        return False
+
+    merged_df = lookup_merger.merge_matched_records(
+        target_df=target_df,
+        lookup_df=lookup_df,
+        lookup_key=transform_config.get("lookup_key_column"),
+        target_key=transform_config.get("target_key_column"),
+        value_columns=transform_config.get("lookup_value_columns"),
+    )
+
+    csv_utils.write_out_data_frame(
+        merged_df,
+        transform_config.get("lookup_output_path"),
+        parser_config.get("inputFileEncoding", "utf-8-sig"),
+    )
+
+    return True
+
+
 def run():
     ap = argparse.ArgumentParser()
     ap.add_argument(

--- a/tact/control/controller.py
+++ b/tact/control/controller.py
@@ -13,6 +13,7 @@ import tact.processing.quality_checker as quality_checker
 import tact.processing.xml_generator as xml_generator
 import tact.processing.taxonomic_name_matcher as taxa_matcher
 import tact.processing.forecaster as forecaster
+import tact.processing.lookup_merger as lookup_merger
 import tact.util.constants as constants
 import tact.util.csv_utils as csv_utils
 from tact.control.logging_controller import LoggingController as loggingController
@@ -624,8 +625,6 @@ def lookup_data() -> bool:
     Returns:
         bool: True if merge succeeded.
     """
-    import tact.processing.lookup_merger as lookup_merger
-
     transform_config = get_settings_json("transform")
     parser_config = get_settings_json("parser")
 
@@ -651,6 +650,10 @@ def lookup_data() -> bool:
         target_key=transform_config.get("target_key_column"),
         value_columns=transform_config.get("lookup_value_columns"),
     )
+
+    if merged_df is None:
+        logger.error("Merge returned None — no output written.")
+        return False
 
     csv_utils.write_out_data_frame(
         merged_df,

--- a/tact/control/controller.py
+++ b/tact/control/controller.py
@@ -119,6 +119,8 @@ def get_data(kwargs: Dict = {}) -> Union[pd.DataFrame, str, Dict]:
                 file_path = config.get("inputPath")
             elif request_type == "transform":
                 file_path = config.get("transform_output_path")
+            elif request_type == "lookup":
+                file_path = config.get("lookup_path")
     except ValueError as e:
         logger.error(
             f"Unknown request type: {request_type}: {e}"
@@ -126,33 +128,35 @@ def get_data(kwargs: Dict = {}) -> Union[pd.DataFrame, str, Dict]:
 
 
     file_path = Path(file_path)
-    if file_path.is_dir():
-        logger.info(f"Input path is directory: {file_path}")
-        files = [f for f in file_path.iterdir() if not list(f.name)[0] == "." and f.is_file()]
+    #TODO: it's extremely unclear to me why this chunk exisits- why update parser config here?
+    if request_type != "lookup":
+        if file_path.is_dir():
+            logger.info(f"Input path is directory: {file_path}")
+            files = [f for f in file_path.iterdir() if not list(f.name)[0] == "." and f.is_file()]
 
-        logger.info(f"Found files: {files}")
-        logger.info("First file will be used for config.")
-        
-        file_path = files[0]
-        
-        update_settings(
-            config_type="parser",
-            json_to_apply={
-                "pathForPreview": str(file_path),
-                "isDirectory": True,
-                "targetFiles": [str(path) for path in files],
-                }
-            )
-    else:
-        update_settings(
-            config_type="parser",
-            json_to_apply={
-                "pathForPreview": str(file_path),
-                "isDirectory": False,
-                "concatFiles": False,
-                "targetFiles": None,
-                }
-            )
+            logger.info(f"Found files: {files}")
+            logger.info("First file will be used for config.")
+            
+            file_path = files[0]
+            
+            update_settings(
+                config_type="parser",
+                json_to_apply={
+                    "pathForPreview": str(file_path),
+                    "isDirectory": True,
+                    "targetFiles": [str(path) for path in files],
+                    }
+                )
+        else:
+            update_settings(
+                config_type="parser",
+                json_to_apply={
+                    "pathForPreview": str(file_path),
+                    "isDirectory": False,
+                    "concatFiles": False,
+                    "targetFiles": None,
+                    }
+                )
         
     if file_path.suffix == ".csv":
 
@@ -584,34 +588,21 @@ def evaluate_forecast() -> Dict:
         **combined_df.to_dict()
     }
 
-
-def upload_lookup_file(file_path: str) -> bool:
-    """Reads column headers from the uploaded lookup CSV and persists the
-    file path and field names into the transform config.
-
-    Args:
-        file_path (str): Absolute path to the uploaded lookup CSV file.
-
-    Returns:
-        bool: True if config was updated successfully.
-    """
-    logger.info(f"Processing uploaded lookup file: {file_path}")
+#TODO - this exists purely to update one field in config, can it be incorporated elsewhere?
+def update_lookup_config() -> None:
+    """Reads column headers from a lookup CSV and updates the transform config."""
     try:
-        # Read only the header row to extract column names
-        lookup_df = pd.read_csv(file_path, nrows=0)
+        lookup_df = get_data(kwargs={"format": "dataframe", "request_type": "lookup"})
         field_names = list(lookup_df.columns)
-        logger.debug(f"Lookup file columns: {field_names}")
-
-        return update_settings("transform", {
-            "lookup_file_path": file_path,
-            "lookup_field_names": field_names,
-        })
     except Exception as e:
-        logger.error(f"Failed to process lookup file: {e}")
-        return False
+        logger.error(f"Failed to read lookup file columns: {e}")
+        field_names = []
+    update_settings("transform", {
+        "lookup_field_names": field_names,
+    })
 
 
-def lookup_data() -> bool:
+def merge_lookup_data() -> bool:
     """Reads lookup/merge configuration from the transform config and
     delegates to the processing module.
 
@@ -637,8 +628,7 @@ def lookup_data() -> bool:
     target_df = get_data(kwargs={"format": "dataframe"})
 
     try:
-        #TODO:Can we get this using get_data?
-        lookup_df = pd.read_csv(transform_config.get("lookup_file_path"))
+        lookup_df = get_data(kwargs={"format": "dataframe", "request_type": "lookup"})
     except Exception as e:
         logger.error(f"Failed to read lookup file: {e}")
         return False

--- a/tact/processing/analyzer.py
+++ b/tact/processing/analyzer.py
@@ -118,7 +118,7 @@ def process_file(input_path, input_encoding):
     config["dateFields"] = find_date_components(field_names)
     config["timeField"] = find_time_field(field_names)
 
-    # THIS SHOULD NOT BE WRITING SETTINGS DIRECTLY :(
+    # TODO THIS SHOULD NOT BE WRITING SETTINGS DIRECTLY :(
     # USE THE API or update_settings in controller
     # write out settings file
     with open(constants.CONFIG_FILE_PATHS["parser"], "w") as outfile:

--- a/tact/processing/lookup_merger.py
+++ b/tact/processing/lookup_merger.py
@@ -4,7 +4,19 @@ from tact.control.logging_controller import LoggingController as loggingControll
 logger = loggingController.get_logger(__name__)
 
 def merge_matched_records(target_df: pd.DataFrame, lookup_df: pd.DataFrame, target_key: str, lookup_key: str, value_columns: list[str]):
-    
+    if target_key not in target_df.columns:
+        logger.error(f"target_key '{target_key}' not found in target columns: {list(target_df.columns)}")
+        return None
+
+    if lookup_key not in lookup_df.columns:
+        logger.error(f"lookup_key '{lookup_key}' not found in lookup columns: {list(lookup_df.columns)}")
+        return None
+
+    missing_cols = [c for c in value_columns if c not in lookup_df.columns]
+    if missing_cols:
+        logger.error(f"value_columns not found in lookup: {missing_cols}")
+        return None
+
     try:
         logger.info(f"Merging matched records on {target_key} in target and {lookup_key} in lookup.")
 
@@ -12,8 +24,8 @@ def merge_matched_records(target_df: pd.DataFrame, lookup_df: pd.DataFrame, targ
 
     except Exception as e:
         logger.error(
-            "Merge FAILED. Something has gone horribly awry!"
-            f" Check log for debug information. Error: {e.with_traceback}",
+            "Merge FAILED. Something has gone horribly awry! "
+            f"Check log for debug information. Error: {e}",
         )
         return None
 

--- a/tact/processing/lookup_merger.py
+++ b/tact/processing/lookup_merger.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from tact.control.logging_controller import LoggingController as loggingController
+
+logger = loggingController.get_logger(__name__)
+
+def merge_matched_records(target_df: pd.DataFrame, lookup_df: pd.DataFrame, target_key: str, lookup_key: str, value_columns: list[str]):
+    
+    try:
+        logger.info(f"Merging matched records on {target_key} in target and {lookup_key} in lookup.")
+
+        merged_df = pd.merge(target_df, lookup_df[value_columns], left_on=target_key, right_on=lookup_key, how='left')
+
+    except Exception as e:
+        logger.error(
+            "Merge FAILED. Something has gone horribly awry!"
+            f" Check log for debug information. Error: {e.with_traceback}",
+        )
+        return None
+
+    logger.info("Merge Successful.")
+    return merged_df

--- a/tact/util/constants.py
+++ b/tact/util/constants.py
@@ -1,4 +1,4 @@
-CONFIG_TYPES = {"parser": "parser", "QA": "QA", "log": "log"}
+CONFIG_TYPES = {"parser": "parser", "transform": "transform", "QA": "QA", "log": "log"}
 CONFIG_FILE_PATHS = {
     "parser": "tact/config/parserConfig.JSON",
     "LOG_CONFIG_PATH": "tact/config/logConfig.JSON",
@@ -7,6 +7,7 @@ CONFIG_FILE_PATHS = {
     "IOOS_QC_CONFIG_PATH": "tact/config/qc_configs/qc_config.json",
     "transform": "tact/config/transformConfig.JSON",
     "forecast": "tact/config/forecastConfig.JSON",
+    "lookup": "tact/config/transformConfig.JSON",
 }
 PARSER_CONFIG_FILE_PATH = (
     "tact/config/parserConfig.JSON"


### PR DESCRIPTION
Adds the ability to merge selected columns from rows within a lookup table (external dataset) into the currently loaded dataset. Users specify the target key in each dataset, and matching row values are concatenated to existing rows.

Required a retool of the file upload functionality, as there are now multiple types of loaded files (e.g. target dataset and lookup table).

<img width="1037" height="728" alt="Screenshot 2026-05-16 at 3 35 39 PM" src="https://github.com/user-attachments/assets/73f4529f-2fea-4dc3-9681-a4f691bfdfd3" />
